### PR TITLE
fix(emotion): externalise emotion libs in vite config and move to peer dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+.lh

--- a/package.json
+++ b/package.json
@@ -27,7 +27,9 @@
   },
   "peerDependencies": {
     "react": ">=18.1.0",
-    "react-dom": ">=18.1.0"
+    "react-dom": ">=18.1.0",
+    "@emotion/react": "^11.10.8",
+    "@emotion/styled": "^11.10.8"
   },
   "scripts": {
     "dev": "vite",
@@ -49,5 +51,6 @@
     "vite": "^5.1.3",
     "vite-plugin-css-injected-by-js": "^3.4.0",
     "vite-plugin-radar": "^0.9.3"
-  }
+  },
+  "packageManager": "pnpm@9.15.9+sha512.68046141893c66fad01c079231128e9afb89ef87e2691d69e4d40eee228988295fd4682181bae55b58418c3a253bde65a505ec7c5f9403ece5cc3cd37dcf2531"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,21 +8,27 @@ importers:
 
   .:
     dependencies:
+      '@emotion/react':
+        specifier: ^11.10.8
+        version: 11.14.0(@types/react@18.3.3)(react@18.1.0)
+      '@emotion/styled':
+        specifier: ^11.10.8
+        version: 11.14.0(@emotion/react@11.14.0(@types/react@18.3.3)(react@18.1.0))(@types/react@18.3.3)(react@18.1.0)
       '@minoru/react-dnd-treeview':
         specifier: ^2.0.0-alpha.6
         version: 2.0.2(react-dnd@16.0.1(@types/react@18.3.3)(react@18.1.0))(react-dom@18.1.0(react@18.1.0))(react@18.1.0)
       '@mui/icons-material':
         specifier: 5.6.2
-        version: 5.6.2(@mui/material@5.6.4(@emotion/react@11.9.0(@types/react@18.3.3)(react@18.1.0))(@emotion/styled@11.8.1(@emotion/react@11.9.0(@types/react@18.3.3)(react@18.1.0))(@types/react@18.3.3)(react@18.1.0))(@types/react@18.3.3)(react-dom@18.1.0(react@18.1.0))(react@18.1.0))(@types/react@18.3.3)(react@18.1.0)
+        version: 5.6.2(@mui/material@5.6.4(@emotion/react@11.14.0(@types/react@18.3.3)(react@18.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.3)(react@18.1.0))(@types/react@18.3.3)(react@18.1.0))(@types/react@18.3.3)(react-dom@18.1.0(react@18.1.0))(react@18.1.0))(@types/react@18.3.3)(react@18.1.0)
       '@mui/material':
         specifier: 5.6.4
-        version: 5.6.4(@emotion/react@11.9.0(@types/react@18.3.3)(react@18.1.0))(@emotion/styled@11.8.1(@emotion/react@11.9.0(@types/react@18.3.3)(react@18.1.0))(@types/react@18.3.3)(react@18.1.0))(@types/react@18.3.3)(react-dom@18.1.0(react@18.1.0))(react@18.1.0)
+        version: 5.6.4(@emotion/react@11.14.0(@types/react@18.3.3)(react@18.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.3)(react@18.1.0))(@types/react@18.3.3)(react@18.1.0))(@types/react@18.3.3)(react-dom@18.1.0(react@18.1.0))(react@18.1.0)
       jotai:
         specifier: ^2.7.0
         version: 2.8.4(@types/react@18.3.3)(react@18.1.0)
       mui-file-input:
         specifier: ^4.0.4
-        version: 4.0.4(@emotion/react@11.9.0(@types/react@18.3.3)(react@18.1.0))(@emotion/styled@11.8.1(@emotion/react@11.9.0(@types/react@18.3.3)(react@18.1.0))(@types/react@18.3.3)(react@18.1.0))(@mui/material@5.6.4(@emotion/react@11.9.0(@types/react@18.3.3)(react@18.1.0))(@emotion/styled@11.8.1(@emotion/react@11.9.0(@types/react@18.3.3)(react@18.1.0))(@types/react@18.3.3)(react@18.1.0))(@types/react@18.3.3)(react-dom@18.1.0(react@18.1.0))(react@18.1.0))(@types/react@18.3.3)(react-dom@18.1.0(react@18.1.0))(react@18.1.0)
+        version: 4.0.4(@emotion/react@11.14.0(@types/react@18.3.3)(react@18.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.3)(react@18.1.0))(@types/react@18.3.3)(react@18.1.0))(@mui/material@5.6.4(@emotion/react@11.14.0(@types/react@18.3.3)(react@18.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.3)(react@18.1.0))(@types/react@18.3.3)(react@18.1.0))(@types/react@18.3.3)(react-dom@18.1.0(react@18.1.0))(react@18.1.0))(@types/react@18.3.3)(react-dom@18.1.0(react@18.1.0))(react@18.1.0)
       opfs-tools:
         specifier: ^0.7.2
         version: 0.7.2
@@ -184,15 +190,12 @@ packages:
   '@emotion/memoize@0.9.0':
     resolution: {integrity: sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==}
 
-  '@emotion/react@11.9.0':
-    resolution: {integrity: sha512-lBVSF5d0ceKtfKCDQJveNAtkC7ayxpVlgOohLgXqRwqWr9bOf4TZAFFyIcNngnV6xK6X4x2ZeXq7vliHkoVkxQ==}
+  '@emotion/react@11.14.0':
+    resolution: {integrity: sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==}
     peerDependencies:
-      '@babel/core': ^7.0.0
       '@types/react': '*'
       react: '>=16.8.0'
     peerDependenciesMeta:
-      '@babel/core':
-        optional: true
       '@types/react':
         optional: true
 
@@ -205,30 +208,29 @@ packages:
   '@emotion/sheet@1.4.0':
     resolution: {integrity: sha512-fTBW9/8r2w3dXWYM4HCB1Rdp8NLibOw2+XELH5m5+AkWiL/KqYX6dc0kKYlaYyKjrQ6ds33MCdMPEwgs2z1rqg==}
 
-  '@emotion/styled@11.8.1':
-    resolution: {integrity: sha512-OghEVAYBZMpEquHZwuelXcRjRJQOVayvbmNR0zr174NHdmMgrNkLC6TljKC5h9lZLkN5WGrdUcrKlOJ4phhoTQ==}
+  '@emotion/styled@11.14.0':
+    resolution: {integrity: sha512-XxfOnXFffatap2IyCeJyNov3kiDQWoR08gPUQxvbL7fxKryGBKUZUkG6Hz48DZwVrJSVh9sJboyV1Ds4OW6SgA==}
     peerDependencies:
-      '@babel/core': ^7.0.0
       '@emotion/react': ^11.0.0-rc.0
       '@types/react': '*'
       react: '>=16.8.0'
     peerDependenciesMeta:
-      '@babel/core':
-        optional: true
       '@types/react':
         optional: true
 
   '@emotion/unitless@0.10.0':
     resolution: {integrity: sha512-dFoMUuQA20zvtVTuxZww6OHoJYgrzfKM1t52mVySDJnMSEa08ruEvdYQbhvyu6soU+NeLVd3yKfTfT0NeV6qGg==}
 
+  '@emotion/use-insertion-effect-with-fallbacks@1.2.0':
+    resolution: {integrity: sha512-yJMtVdH59sxi/aVJBpk9FQq+OR8ll5GT8oWd57UpeaKEVGab41JWaCFA7FRLoMLloOZF/c/wsPoe+bfGmRKgDg==}
+    peerDependencies:
+      react: '>=16.8.0'
+
   '@emotion/utils@1.2.1':
     resolution: {integrity: sha512-Y2tGf3I+XVnajdItskUCn6LX+VUDmP6lTL4fcqsXAv43dnlbZiuW4MWQW38rW/BVWSE7Q/7+XQocmpnRYILUmg==}
 
   '@emotion/utils@1.4.2':
     resolution: {integrity: sha512-3vLclRofFziIa3J2wDh9jjbkUz9qk5Vi3IZ/FSTKViB0k+ef0fPV7dYrUIugbgupYDx7v9ud/SjrtEP8Y4xLoA==}
-
-  '@emotion/weak-memoize@0.2.5':
-    resolution: {integrity: sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA==}
 
   '@emotion/weak-memoize@0.3.1':
     resolution: {integrity: sha512-EsBwpc7hBUJWAsNPBmJy4hxWx12v6bshQsldrVmjxJoc3isbxhOrF2IcCpaXxfvq03NwkI7sbsOLXbYuqF/8Ww==}
@@ -1549,14 +1551,15 @@ snapshots:
 
   '@emotion/memoize@0.9.0': {}
 
-  '@emotion/react@11.9.0(@types/react@18.3.3)(react@18.1.0)':
+  '@emotion/react@11.14.0(@types/react@18.3.3)(react@18.1.0)':
     dependencies:
       '@babel/runtime': 7.26.10
       '@emotion/babel-plugin': 11.13.5
       '@emotion/cache': 11.14.0
       '@emotion/serialize': 1.3.3
+      '@emotion/use-insertion-effect-with-fallbacks': 1.2.0(react@18.1.0)
       '@emotion/utils': 1.4.2
-      '@emotion/weak-memoize': 0.2.5
+      '@emotion/weak-memoize': 0.4.0
       hoist-non-react-statics: 3.3.2
       react: 18.1.0
     optionalDependencies:
@@ -1576,13 +1579,14 @@ snapshots:
 
   '@emotion/sheet@1.4.0': {}
 
-  '@emotion/styled@11.8.1(@emotion/react@11.9.0(@types/react@18.3.3)(react@18.1.0))(@types/react@18.3.3)(react@18.1.0)':
+  '@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.3)(react@18.1.0))(@types/react@18.3.3)(react@18.1.0)':
     dependencies:
       '@babel/runtime': 7.26.10
       '@emotion/babel-plugin': 11.13.5
       '@emotion/is-prop-valid': 1.3.1
-      '@emotion/react': 11.9.0(@types/react@18.3.3)(react@18.1.0)
+      '@emotion/react': 11.14.0(@types/react@18.3.3)(react@18.1.0)
       '@emotion/serialize': 1.3.3
+      '@emotion/use-insertion-effect-with-fallbacks': 1.2.0(react@18.1.0)
       '@emotion/utils': 1.4.2
       react: 18.1.0
     optionalDependencies:
@@ -1592,11 +1596,13 @@ snapshots:
 
   '@emotion/unitless@0.10.0': {}
 
+  '@emotion/use-insertion-effect-with-fallbacks@1.2.0(react@18.1.0)':
+    dependencies:
+      react: 18.1.0
+
   '@emotion/utils@1.2.1': {}
 
   '@emotion/utils@1.4.2': {}
-
-  '@emotion/weak-memoize@0.2.5': {}
 
   '@emotion/weak-memoize@0.3.1': {}
 
@@ -1728,19 +1734,19 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.3
 
-  '@mui/icons-material@5.6.2(@mui/material@5.6.4(@emotion/react@11.9.0(@types/react@18.3.3)(react@18.1.0))(@emotion/styled@11.8.1(@emotion/react@11.9.0(@types/react@18.3.3)(react@18.1.0))(@types/react@18.3.3)(react@18.1.0))(@types/react@18.3.3)(react-dom@18.1.0(react@18.1.0))(react@18.1.0))(@types/react@18.3.3)(react@18.1.0)':
+  '@mui/icons-material@5.6.2(@mui/material@5.6.4(@emotion/react@11.14.0(@types/react@18.3.3)(react@18.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.3)(react@18.1.0))(@types/react@18.3.3)(react@18.1.0))(@types/react@18.3.3)(react-dom@18.1.0(react@18.1.0))(react@18.1.0))(@types/react@18.3.3)(react@18.1.0)':
     dependencies:
       '@babel/runtime': 7.24.7
-      '@mui/material': 5.6.4(@emotion/react@11.9.0(@types/react@18.3.3)(react@18.1.0))(@emotion/styled@11.8.1(@emotion/react@11.9.0(@types/react@18.3.3)(react@18.1.0))(@types/react@18.3.3)(react@18.1.0))(@types/react@18.3.3)(react-dom@18.1.0(react@18.1.0))(react@18.1.0)
+      '@mui/material': 5.6.4(@emotion/react@11.14.0(@types/react@18.3.3)(react@18.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.3)(react@18.1.0))(@types/react@18.3.3)(react@18.1.0))(@types/react@18.3.3)(react-dom@18.1.0(react@18.1.0))(react@18.1.0)
       react: 18.1.0
     optionalDependencies:
       '@types/react': 18.3.3
 
-  '@mui/material@5.6.4(@emotion/react@11.9.0(@types/react@18.3.3)(react@18.1.0))(@emotion/styled@11.8.1(@emotion/react@11.9.0(@types/react@18.3.3)(react@18.1.0))(@types/react@18.3.3)(react@18.1.0))(@types/react@18.3.3)(react-dom@18.1.0(react@18.1.0))(react@18.1.0)':
+  '@mui/material@5.6.4(@emotion/react@11.14.0(@types/react@18.3.3)(react@18.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.3)(react@18.1.0))(@types/react@18.3.3)(react@18.1.0))(@types/react@18.3.3)(react-dom@18.1.0(react@18.1.0))(react@18.1.0)':
     dependencies:
       '@babel/runtime': 7.24.7
       '@mui/base': 5.0.0-alpha.79(@types/react@18.3.3)(react-dom@18.1.0(react@18.1.0))(react@18.1.0)
-      '@mui/system': 5.15.20(@emotion/react@11.9.0(@types/react@18.3.3)(react@18.1.0))(@emotion/styled@11.8.1(@emotion/react@11.9.0(@types/react@18.3.3)(react@18.1.0))(@types/react@18.3.3)(react@18.1.0))(@types/react@18.3.3)(react@18.1.0)
+      '@mui/system': 5.15.20(@emotion/react@11.14.0(@types/react@18.3.3)(react@18.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.3)(react@18.1.0))(@types/react@18.3.3)(react@18.1.0))(@types/react@18.3.3)(react@18.1.0)
       '@mui/types': 7.2.14(@types/react@18.3.3)
       '@mui/utils': 5.15.20(@types/react@18.3.3)(react@18.1.0)
       '@types/react-transition-group': 4.4.10
@@ -1753,8 +1759,8 @@ snapshots:
       react-is: 17.0.2
       react-transition-group: 4.4.5(react-dom@18.1.0(react@18.1.0))(react@18.1.0)
     optionalDependencies:
-      '@emotion/react': 11.9.0(@types/react@18.3.3)(react@18.1.0)
-      '@emotion/styled': 11.8.1(@emotion/react@11.9.0(@types/react@18.3.3)(react@18.1.0))(@types/react@18.3.3)(react@18.1.0)
+      '@emotion/react': 11.14.0(@types/react@18.3.3)(react@18.1.0)
+      '@emotion/styled': 11.14.0(@emotion/react@11.14.0(@types/react@18.3.3)(react@18.1.0))(@types/react@18.3.3)(react@18.1.0)
       '@types/react': 18.3.3
 
   '@mui/private-theming@5.15.20(@types/react@18.3.3)(react@18.1.0)':
@@ -1766,7 +1772,7 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.3
 
-  '@mui/styled-engine@5.15.14(@emotion/react@11.9.0(@types/react@18.3.3)(react@18.1.0))(@emotion/styled@11.8.1(@emotion/react@11.9.0(@types/react@18.3.3)(react@18.1.0))(@types/react@18.3.3)(react@18.1.0))(react@18.1.0)':
+  '@mui/styled-engine@5.15.14(@emotion/react@11.14.0(@types/react@18.3.3)(react@18.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.3)(react@18.1.0))(@types/react@18.3.3)(react@18.1.0))(react@18.1.0)':
     dependencies:
       '@babel/runtime': 7.24.7
       '@emotion/cache': 11.11.0
@@ -1774,14 +1780,14 @@ snapshots:
       prop-types: 15.8.1
       react: 18.1.0
     optionalDependencies:
-      '@emotion/react': 11.9.0(@types/react@18.3.3)(react@18.1.0)
-      '@emotion/styled': 11.8.1(@emotion/react@11.9.0(@types/react@18.3.3)(react@18.1.0))(@types/react@18.3.3)(react@18.1.0)
+      '@emotion/react': 11.14.0(@types/react@18.3.3)(react@18.1.0)
+      '@emotion/styled': 11.14.0(@emotion/react@11.14.0(@types/react@18.3.3)(react@18.1.0))(@types/react@18.3.3)(react@18.1.0)
 
-  '@mui/system@5.15.20(@emotion/react@11.9.0(@types/react@18.3.3)(react@18.1.0))(@emotion/styled@11.8.1(@emotion/react@11.9.0(@types/react@18.3.3)(react@18.1.0))(@types/react@18.3.3)(react@18.1.0))(@types/react@18.3.3)(react@18.1.0)':
+  '@mui/system@5.15.20(@emotion/react@11.14.0(@types/react@18.3.3)(react@18.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.3)(react@18.1.0))(@types/react@18.3.3)(react@18.1.0))(@types/react@18.3.3)(react@18.1.0)':
     dependencies:
       '@babel/runtime': 7.24.7
       '@mui/private-theming': 5.15.20(@types/react@18.3.3)(react@18.1.0)
-      '@mui/styled-engine': 5.15.14(@emotion/react@11.9.0(@types/react@18.3.3)(react@18.1.0))(@emotion/styled@11.8.1(@emotion/react@11.9.0(@types/react@18.3.3)(react@18.1.0))(@types/react@18.3.3)(react@18.1.0))(react@18.1.0)
+      '@mui/styled-engine': 5.15.14(@emotion/react@11.14.0(@types/react@18.3.3)(react@18.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.3)(react@18.1.0))(@types/react@18.3.3)(react@18.1.0))(react@18.1.0)
       '@mui/types': 7.2.14(@types/react@18.3.3)
       '@mui/utils': 5.15.20(@types/react@18.3.3)(react@18.1.0)
       clsx: 2.1.1
@@ -1789,8 +1795,8 @@ snapshots:
       prop-types: 15.8.1
       react: 18.1.0
     optionalDependencies:
-      '@emotion/react': 11.9.0(@types/react@18.3.3)(react@18.1.0)
-      '@emotion/styled': 11.8.1(@emotion/react@11.9.0(@types/react@18.3.3)(react@18.1.0))(@types/react@18.3.3)(react@18.1.0)
+      '@emotion/react': 11.14.0(@types/react@18.3.3)(react@18.1.0)
+      '@emotion/styled': 11.14.0(@emotion/react@11.14.0(@types/react@18.3.3)(react@18.1.0))(@types/react@18.3.3)(react@18.1.0)
       '@types/react': 18.3.3
 
   '@mui/types@7.2.14(@types/react@18.3.3)':
@@ -2211,11 +2217,11 @@ snapshots:
 
   ms@2.1.3: {}
 
-  mui-file-input@4.0.4(@emotion/react@11.9.0(@types/react@18.3.3)(react@18.1.0))(@emotion/styled@11.8.1(@emotion/react@11.9.0(@types/react@18.3.3)(react@18.1.0))(@types/react@18.3.3)(react@18.1.0))(@mui/material@5.6.4(@emotion/react@11.9.0(@types/react@18.3.3)(react@18.1.0))(@emotion/styled@11.8.1(@emotion/react@11.9.0(@types/react@18.3.3)(react@18.1.0))(@types/react@18.3.3)(react@18.1.0))(@types/react@18.3.3)(react-dom@18.1.0(react@18.1.0))(react@18.1.0))(@types/react@18.3.3)(react-dom@18.1.0(react@18.1.0))(react@18.1.0):
+  mui-file-input@4.0.4(@emotion/react@11.14.0(@types/react@18.3.3)(react@18.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.3)(react@18.1.0))(@types/react@18.3.3)(react@18.1.0))(@mui/material@5.6.4(@emotion/react@11.14.0(@types/react@18.3.3)(react@18.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.3)(react@18.1.0))(@types/react@18.3.3)(react@18.1.0))(@types/react@18.3.3)(react-dom@18.1.0(react@18.1.0))(react@18.1.0))(@types/react@18.3.3)(react-dom@18.1.0(react@18.1.0))(react@18.1.0):
     dependencies:
-      '@emotion/react': 11.9.0(@types/react@18.3.3)(react@18.1.0)
-      '@emotion/styled': 11.8.1(@emotion/react@11.9.0(@types/react@18.3.3)(react@18.1.0))(@types/react@18.3.3)(react@18.1.0)
-      '@mui/material': 5.6.4(@emotion/react@11.9.0(@types/react@18.3.3)(react@18.1.0))(@emotion/styled@11.8.1(@emotion/react@11.9.0(@types/react@18.3.3)(react@18.1.0))(@types/react@18.3.3)(react@18.1.0))(@types/react@18.3.3)(react-dom@18.1.0(react@18.1.0))(react@18.1.0)
+      '@emotion/react': 11.14.0(@types/react@18.3.3)(react@18.1.0)
+      '@emotion/styled': 11.14.0(@emotion/react@11.14.0(@types/react@18.3.3)(react@18.1.0))(@types/react@18.3.3)(react@18.1.0)
+      '@mui/material': 5.6.4(@emotion/react@11.14.0(@types/react@18.3.3)(react@18.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.3)(react@18.1.0))(@types/react@18.3.3)(react@18.1.0))(@types/react@18.3.3)(react-dom@18.1.0(react@18.1.0))(react@18.1.0)
       pretty-bytes: 6.1.1
       react: 18.1.0
       react-dom: 18.1.0(react@18.1.0)

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -21,7 +21,7 @@ const createConfig = (format: 'es' | 'umd', emptyOutDir: boolean) => ({
     rollupOptions: {
       external:
         // es 排除所有非相对路径的导入（即第三方库）
-        format === 'es' ? ['react', 'react-dom'] : [],
+        format === 'es' ? ['react', 'react-dom', '@emotion/react', '@emotion/styled'] : [],
     },
   },
 });


### PR DESCRIPTION
possible fix for https://github.com/hughfenghen/opfs-tools-explorer/issues/12